### PR TITLE
Fix build issue on Mac M2

### DIFF
--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 default = ["gate_testing", "parallel", "rand_chacha", "std", "timing"]
 gate_testing = []
 parallel = ["hashbrown/rayon", "plonky2_maybe_rayon/parallel"]
-std = ["anyhow/std", "rand/std"]
+std = ["anyhow/std", "rand/std", "itertools/use_std"]
 timing = ["std"]
 
 [dependencies]


### PR DESCRIPTION
Add itertools/use_std feature to the "std" features, resolves a build issue on Mac M2